### PR TITLE
Save logs in the .config/antfs-cli/logs directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ANT-FS Client
 
 This program extracts all activity FIT files from a device and writes them
 to a folder (see file locations below). The first time it runs it attempts
-to sync with the watch. This produces an authfile which is written to the
+to sync with the watch. This produces an `authfile` which is written to the
 same folder. On startup this program will try to read that file to avoid
 having to re-sync.
 
@@ -28,15 +28,16 @@ File locations
 
 ### Simple answer (probably correct for most people)
 
-Your files are placed in ~/.config/antfs-cli/
+Your files are placed in `~/.config/antfs-cli/`
 
 ### Long answer
 
 FIT files and authfiles are stored in an the location specified by the XDG
-Base Directory specification. It uses the $XDG_CONFIG_HOME with
-$HOME/.config as backup. In this directory a antfs-cli folder is created
-in which a folder for each device is created. Both the .FIT files and
-authfile are stored in this device-specific folder.
+Base Directory specification. It uses the `$XDG_CONFIG_HOME` with
+`$HOME/.config` as backup. In this directory a `antfs-cli` folder is created
+in which a folder for each device is created. Both the `.FIT` files and
+`authfile` are stored in this device-specific folder. All logs are stored
+in a `logs` subfolder of the `antfs-cli` directory.
 
 Supported devices
 -----------------

--- a/SCRIPTING
+++ b/SCRIPTING
@@ -1,7 +1,7 @@
 Scripting
 ==============================================================================
 
-In the location for scripts, usually ~/.config/antfs-cli/XXXXX/scripts
+In the location for scripts, usually ~/.config/antfs-cli/scripts
 (but see README, for more precise location) you can add executable scripts
 and programs.
 
@@ -13,7 +13,7 @@ The three arguments to the executables are:
  - Action (DOWNLOAD, UPLOAD or DELETE -- depending on what action caused the
    script to run)
 
- - File name 
+ - File name
 
  - FIT type (e.g. 4 for an Activity, see File.Identifier in ant/fs/file.py
    for other FIT file types)


### PR DESCRIPTION
Had to remove `logger.debug("Creating directories")` -- because I can't open a logfile before creating config & log dirs -- and moved `makedirs_if_not_exists(config_dir)` from `AntFSCLI.__init__()` to `main()`.
Also added information about logs location to the README.

Closes #57.

Tested with Python 2.7.8 and 3.4.2.